### PR TITLE
reordenamiento de codigo/campo más soluciones de bug

### DIFF
--- a/DAES.BLL/Custom.cs
+++ b/DAES.BLL/Custom.cs
@@ -24,6 +24,12 @@ using Microsoft.AspNet.Identity.EntityFramework;
 using static iTextSharp.text.pdf.AcroFields;
 using System.Web.Services.Description;
 using OfficeOpenXml.FormulaParsing.Excel.Functions.Math;
+using System.Web.UI.WebControls;
+using Image = iTextSharp.text.Image;
+using System.Windows.Input;
+using OfficeOpenXml.Style;
+using Org.BouncyCastle.Asn1.X500;
+using OfficeOpenXml.FormulaParsing.Excel.Functions.Text;
 //using DAES.bll.Interfaces;
 
 namespace DAES.BLL
@@ -521,7 +527,7 @@ namespace DAES.BLL
                         exi.Fojas = item.Fojas;
                         exi.AnoInscripcion = item.AnoInscripcion;
                         exi.DatosCBR = item.DatosCBR;
-                        exi.LugarNotario = item.LugarNotario;
+                        exi.LugarNotarioP = item.LugarNotarioP;
                         exi.TipoGeneralId = item.TipoGeneralId;
                     }
 
@@ -553,7 +559,7 @@ namespace DAES.BLL
                         sane.Fojass = item.Fojass;
                         sane.FechaaInscripcion = item.FechaaInscripcion;
                         sane.DatossCBR = item.DatossCBR;
-                        sane.LugarNotario = item.LugarNotario;
+                        sane.LugarNotarioSa = item.LugarNotarioSa;
                         //Sane.OrganizacionId = item.OrganizacionId;
 
 
@@ -1467,7 +1473,11 @@ namespace DAES.BLL
                 string parrafos = string.Format(configuracioncertificado.Parrafo1 != null ? configuracioncertificado.Parrafo1 : " ");
 
                 var tipoOrganizacion = context.TipoOrganizacion.Find(organizacion.TipoOrganizacionId);
-
+                float marginLeft = doc.LeftMargin;
+                float marginRight = doc.RightMargin;
+                float marginTop = doc.TopMargin;
+                float marginBottom = doc.BottomMargin;
+                doc.SetMargins(marginLeft, marginRight, marginTop, 72);
                 doc.Open();
 
                 doc.AddTitle(configuracioncertificado.Titulo);
@@ -1491,10 +1501,7 @@ namespace DAES.BLL
 
                 Phrase PhraseUNO;
                 Phrase PhraseDOS;
-                Phrase PhraseDOSSuperior;
-                Phrase PhraseDOSInferior;
                 Phrase PhraseTRES;
-                Phrase PhraseCINCO;
                 Paragraph subtitulo;
                 Paragraph subtitulo2 = null;
                 Paragraph subtitulo3 = null;
@@ -1519,6 +1526,70 @@ namespace DAES.BLL
                 }
 
                 Image imagenLogo = Image.GetInstance(logo.Valor);
+                imagenLogo.ScalePercent(20);
+
+                PdfPTable tableHeader = new PdfPTable(1);
+                tableHeader.WidthPercentage = 100f;
+                tableHeader.DefaultCell.Border = Rectangle.NO_BORDER;
+                tableHeader.DefaultCell.Border = 0;
+
+                // Logo en una fila de 3 columnas
+                PdfPTable logoTable = new PdfPTable(3);
+                logoTable.DefaultCell.Border = Rectangle.NO_BORDER;
+                logoTable.DefaultCell.Border = 0;
+
+                PdfPCell logoCell = new PdfPCell(imagenLogo);
+                logoCell.HorizontalAlignment = Element.ALIGN_LEFT;
+                logoCell.BorderWidth = 0;
+                logoCell.PaddingTop = 20;
+                logoCell.Border = Rectangle.NO_BORDER;
+                logoTable.AddCell(logoCell);
+
+                // Añadir dos celdas vacías para completar las 3 columnas
+                for (int i = 0; i < 2; i++)
+                {
+                    PdfPCell emptyCell = new PdfPCell();
+                    emptyCell.BorderWidth = 0;
+                    logoTable.AddCell(emptyCell);
+                }
+
+                // Añadir la tabla de logos a la tabla principal
+                PdfPCell logoTableCell = new PdfPCell(logoTable);
+                logoTableCell.BorderWidth = 0;
+                tableHeader.AddCell(logoTableCell);
+
+                // Título centrado en la siguiente fila
+                string[] titulo = configuracioncertificado.Titulo.Split('#');
+                Phrase PhraseTitulo;
+                Paragraph tituloFinal = new Paragraph();
+                index = 0;
+                foreach (var element in titulo)
+                {
+                    if (index == 0)
+                    {
+                        PhraseTitulo = new Phrase(element, _fontTitulo);
+                    }
+                    else
+                    {
+                        PhraseTitulo = new Phrase(SaltoLinea + element, _fontTituloSegundario);
+                    }
+                    tituloFinal.Add(PhraseTitulo);
+                    index++;
+                }
+
+                PdfPCell titleCell = new PdfPCell(new Phrase(tituloFinal));
+                titleCell.HorizontalAlignment = Element.ALIGN_CENTER;
+                titleCell.VerticalAlignment = Element.ALIGN_MIDDLE;
+                titleCell.BorderWidth = 0;
+                titleCell.PaddingTop = 20;
+                tableHeader.AddCell(titleCell);
+
+                // ... (continuación de tu código)
+
+                // Agregar la tabla principal al documento
+                doc.Add(tableHeader);
+
+                /*Image imagenLogo = Image.GetInstance(logo.Valor);
                 imagenLogo.ScalePercent(20);
 
                 PdfPTable tableHeader = new PdfPTable(3);
@@ -1580,7 +1651,7 @@ namespace DAES.BLL
                 cell.Border = Rectangle.NO_BORDER;
                 tableHeader.AddCell(cell);
 
-                doc.Add(tableHeader);
+                doc.Add(tableHeader);*/
                 doc.Add(new Paragraph());
 
 
@@ -2046,7 +2117,7 @@ namespace DAES.BLL
                                 {
                                     parrafo3[0] = parrafo3[0].Replace("[EXISTEREFORMA]", organizacion.ReformaAnteriors.Any() || organizacion.ReformaPosteriors.Any() ? "El acta constitutiva" : "La reforma estatutaria");
                                     parrafo3[0] = parrafo3[0].Replace("[FECHAESCRITURA]", saniamientoAnt.FechaEscrituraPublicaa.HasValue ? "#" + string.Format("{0:dd} de {0:MMMM} del {0:yyyy}", saniamientoAnt.FechaEscrituraPublicaa.Value) + "#" : "ERROR_Saneamiento");
-                                    parrafo3[0] = parrafo3[0].Replace("[LUGARNOTARIO]", saniamientoAnt.LugarNotario != null ? "#" + saniamientoAnt.LugarNotario + "#" : "ERROR_Saneamiento");
+                                    parrafo3[0] = parrafo3[0].Replace("[LUGARNOTARIO]", saniamientoAnt.LugarNotarioSa != null ? "#" + saniamientoAnt.LugarNotarioSa + "#" : "ERROR_Saneamiento");
                                     parrafo3[0] = parrafo3[0].Replace("[DATOGENERALNOTARIO]", saniamientoAnt.DatoGeneralesNotario != null ? "#" + saniamientoAnt.DatoGeneralesNotario + "#" : "ERROR_Saneamiento");
                                     parrafo3[0] = parrafo3[0].Replace("[FECHAPUBLICACION]", saniamientoAnt.FechaaPublicacionDiario.HasValue ? "#" + string.Format("{0:dd} de {0:MMMM} del {0:yyyy}", saniamientoAnt.FechaaPublicacionDiario.Value) + "#" : "ERROR_Saneamiento");
                                     if (parrafo3[0].Contains("ERROR_Saneamiento"))
@@ -2362,7 +2433,7 @@ namespace DAES.BLL
                                 parrafo2[0] = parrafo2[0].Replace("[TIPOGENERAL]", LegalPost.TipoGeneralId != null ? "#" + LegalPost.TipoGeneral.Nombre + "#" : "ERROR_Legal");
                                 parrafo2[0] = parrafo2[0].Replace("[FECHAJUNTAGENERALSOCIOS]", LegalPost.FechaConstitutivaSocios.HasValue ? "#" + string.Format("{0:dd} de {0:MMMM} del {0:yyyy}", LegalPost.FechaConstitutivaSocios.Value) + "#" : "ERROR_Legal");
                                 parrafo2[0] = parrafo2[0].Replace("[FECHAESCRITURA]", LegalPost.FechaEscrituraPublica.HasValue ? "#" + string.Format("{0:dd} de {0:MMMM} del {0:yyyy}", LegalPost.FechaEscrituraPublica.Value) + "#" : "ERROR_Legal");
-                                parrafo2[0] = parrafo2[0].Replace("[LUGARNOTARIO]", LegalPost.LugarNotario != null ? "#" + LegalPost.LugarNotario + "#" : "ERROR_Legal");
+                                parrafo2[0] = parrafo2[0].Replace("[LUGARNOTARIO]", LegalPost.LugarNotarioP != null ? "#" + LegalPost.LugarNotarioP + "#" : "ERROR_Legal");
                                 parrafo2[0] = parrafo2[0].Replace("[DATOGENERALNOTARIO]", LegalPost.DatosGeneralesNotario != null ? "#" + LegalPost.DatosGeneralesNotario + "#" : "ERROR_Legal");
                                 parrafo2[0] = parrafo2[0].Replace("[FECHAPUBLICACION]", LegalPost.FechaPublicacionn.HasValue ? "#" + string.Format("{0:dd} de {0:MMMM} del {0:yyyy}", LegalPost.FechaPublicacionn.Value) + "#" : "ERROR_Legal");
                                 parrafo2[0] = parrafo2[0].Replace("[FOJASNUMERO]", LegalPost.Fojas != null ? "#" + LegalPost.Fojas + "#" : "ERROR_Legal");
@@ -2438,7 +2509,7 @@ namespace DAES.BLL
                                 {
                                     parrafo3[0] = parrafo3[0].Replace("[EXISTEREFORMA]", organizacion.ReformaPosteriors.Any() ? "El acta contitutiva" : "La reforma estatutaria");
                                     parrafo3[0] = parrafo3[0].Replace("[FECHAESCRITURA]", saneamientoAnt.FechaEscrituraPublicaa.HasValue ? "#" + string.Format("{0:dd} de {0:MMMM} del {0:yyyy}", saneamientoAnt.FechaEscrituraPublicaa.Value) + "#" : "ERROR_Saneamiento");
-                                    parrafo3[0] = parrafo3[0].Replace("[LUGARNOTARIO]", saneamientoAnt.LugarNotario != null ? "#" + saneamientoAnt.LugarNotario + "#" : "ERROR_Saneamiento");
+                                    parrafo3[0] = parrafo3[0].Replace("[LUGARNOTARIO]", saneamientoAnt.LugarNotarioSa != null ? "#" + saneamientoAnt.LugarNotarioSa + "#" : "ERROR_Saneamiento");
                                     parrafo3[0] = parrafo3[0].Replace("[DATOGENERALNOTARIO]", saneamientoAnt.DatoGeneralesNotario != null ? "#" + saneamientoAnt.DatoGeneralesNotario + "#" : "ERROR_Saneamiento");
                                     parrafo3[0] = parrafo3[0].Replace("[FECHAPUBLICACION]", saneamientoAnt.FechaaPublicacionDiario.HasValue ? "#" + string.Format("{0:dd} de {0:MMMM} del {0:yyyy}", saneamientoAnt.FechaaPublicacionDiario.Value) + "#" : "ERROR_Saneamiento");
                                     parrafo3[0] = parrafo3[0].Replace("[FOJASNUMERO]", saneamientoAnt.Fojass != null ? "#" + saneamientoAnt.Fojass + "#" : "ERROR_Saneamiento");
@@ -3977,7 +4048,7 @@ namespace DAES.BLL
                 doc.Add(SaltoLinea);
                 doc.Add(parraOb);
                 doc.Add(SaltoLinea);
-
+                Paragraph porOrdenpha = new Paragraph();
                 if (organizacion.TipoOrganizacionId == (int)Infrastructure.Enum.TipoOrganizacion.Cooperativa)
                 {
                     //string orden = "Por orden del Subsecretario";
@@ -3989,19 +4060,20 @@ namespace DAES.BLL
                             "la personalidad jurídica de dicha Cooperativa." + "\n" + "\n" +
                             "Saluda atentamente a ustedes";
 
-                        Paragraph porOrden = new Paragraph(orden, _fontStandard);
-                        porOrden.Alignment = Element.ALIGN_JUSTIFIED;
-                        doc.Add(porOrden);
+                        //Paragraph porOrden = new Paragraph(orden, _fontStandard);
+                        //porOrden.Alignment = Element.ALIGN_JUSTIFIED;
+                        //doc.Add(porOrden);
+                        porOrdenpha = new Paragraph(orden, _fontStandard);
                     }
                     else
                     {
 
 
                         string orden = "Saluda atentamente a ustedes.";
-                        Paragraph porOrden = new Paragraph(orden, _fontStandard);
-                        porOrden.Alignment = Element.ALIGN_JUSTIFIED;
-                        doc.Add(porOrden);
-
+                        //Paragraph porOrden = new Paragraph(orden, _fontStandard);
+                        //porOrden.Alignment = Element.ALIGN_JUSTIFIED;
+                        //doc.Add(porOrden);
+                        porOrdenpha = new Paragraph(orden, _fontStandard);
 
                     }
                 }
@@ -4018,17 +4090,20 @@ namespace DAES.BLL
                             // "\n" + "\n" +
                             "Saluda atentamente a ustedes";
 
-                        Paragraph porOrden = new Paragraph(orden, _fontStandard);
-                        porOrden.Alignment = Element.ALIGN_JUSTIFIED;
-                        doc.Add(porOrden);
+                        //Paragraph porOrden = new Paragraph(orden, _fontStandard);
+                        //porOrden.Alignment = Element.ALIGN_JUSTIFIED;
+                        //doc.Add(porOrden);
+                        porOrdenpha = new Paragraph(orden, _fontStandard);
                     }
                     else
                     {
                         string orden = "Saluda atentamente a ustedes.";
-                        Paragraph porOrden = new Paragraph(orden, _fontStandard);
-                        porOrden.Alignment = Element.ALIGN_JUSTIFIED;
-                        doc.Add(porOrden);
+                        //Paragraph porOrden = new Paragraph(orden, _fontStandard);
+                        //porOrden.Alignment = Element.ALIGN_JUSTIFIED;
+                        //doc.Add(porOrden);
+                        porOrdenpha = new Paragraph(orden, _fontStandard);
                     }
+
                 }
                 doc.Add(SaltoLinea);
                 if ((int)DAES.Infrastructure.Enum.TipoDocumento.VigenciaDirectorio == TipoDocumentoId)
@@ -4047,8 +4122,27 @@ namespace DAES.BLL
                     throw new Exception("La configuración de url de rúbrica es inválida.");
                 }
 
+                //xuxu ResponsableFinal
+                porOrdenpha.Alignment = Element.ALIGN_LEFT;
+                var tableSaludo = new PdfPTable(1);
+                var cellSaludo = new PdfPCell();
+                cellSaludo.UseVariableBorders = true;
+                cellSaludo.Border = Rectangle.NO_BORDER;
+                Paragraph ResponsableFinal = new Paragraph();
+                Phrase responsable = new Phrase(firmante.Nombre, _fontStandardBold);
+                //ResponsableFinal.Add(porOrdenpha);
+                ResponsableFinal.Add(SaltoLinea);
+                ResponsableFinal.Add(responsable);
+                ResponsableFinal.Add(SaltoLinea);
+                Phrase _cargo = new Phrase(firmante.Cargo, _fontStandardBold);
+                ResponsableFinal.Add(_cargo); 
+                ResponsableFinal.Add(SaltoLinea);
+                Phrase _unidad = new Phrase(firmante.UnidadOrganizacional, _fontStandardBold);
+                ResponsableFinal.Add(_unidad);
+                ResponsableFinal.Alignment = Element.ALIGN_CENTER;
 
-                Paragraph responsable = new Paragraph(firmante.Nombre, _fontStandardBold);
+                //doc.Add(ResponsableFinal2);
+                /*Paragraph responsable = new Paragraph(firmante.Nombre, _fontStandardBold);
                 responsable.Alignment = centrar;
                 doc.Add(responsable);
 
@@ -4059,7 +4153,20 @@ namespace DAES.BLL
                 Paragraph _unidad = new Paragraph(firmante.UnidadOrganizacional, _fontStandardBold);
                 _unidad.Alignment = centrar;
                 doc.Add(_unidad);
-                doc.Add(SaltoLinea);
+                doc.Add(SaltoLinea);*/
+
+                //var cellSaludo = new PdfPCell(new Phrase("soy contenido de celda"));
+                cellSaludo.AddElement(porOrdenpha);
+                cellSaludo.AddElement(ResponsableFinal);
+                tableSaludo.AddCell(cellSaludo);
+                tableSaludo.DefaultCell.Border = Rectangle.NO_BORDER;
+
+                doc.Add(tableSaludo);
+                //var image = ConvertirTablaAImagen(tableSaludo);
+                //doc.Add(image);
+                //byte[] imagenBytes = ConvertirTablaABytes(tableSaludo);
+                //Image imagenBytes = ConvertirContenidoABytes(ResponsableFinal);
+                //InsertarImagenEnDocumento(imagenBytes, doc);
                 doc.Close();
 
                 return memStream.ToArray();
@@ -4214,8 +4321,8 @@ namespace DAES.BLL
                         Fojass = saneamiento.Fojass,
                         FechaaInscripcion = saneamiento.FechaaInscripcion,
                         DatossCBR = saneamiento.DatossCBR,
-                        LugarNotario = saneamiento.LugarNotario
-                });
+                        LugarNotarioSa = saneamiento.LugarNotarioSa
+                    });
                     context.SaveChanges();
                 }
 
@@ -4321,7 +4428,7 @@ namespace DAES.BLL
                         Fojas = ExiPost.Fojas,
                         AnoInscripcion = ExiPost.AnoInscripcion,
                         DatosCBR = ExiPost.DatosCBR,
-                        LugarNotario = ExiPost.LugarNotario,
+                        LugarNotarioP = ExiPost.LugarNotarioP,
                         TipoGeneralId = ExiPost.TipoGeneralId
                     });
                     context.SaveChanges();
@@ -4440,8 +4547,7 @@ namespace DAES.BLL
                                     ColumnText.ShowTextAligned(pdfContentByte, Element.ALIGN_CENTER, new Phrase(configmensajeVerificacion.Valor + " usando el código " + id, _fontStandard), 300, delta + 0, 0);
                                 }
                             }
-                            finally 
-                            { 
+                            finally { 
                                 stamper.Close();
                             }
                             content = ms.ToArray();
@@ -6412,8 +6518,11 @@ namespace DAES.BLL
                             }
                         }
 
-
-                        var docto = hsms.Sign(documento.File, idsFirma, documento.DocumentoId, documento.Folio, url_tramites_en_linea.Valor, qr);
+                        var organizacionId = documento.OrganizacionId;
+                        var Orga = db.Organizacion.Where(q => q.OrganizacionId == organizacionId).ToList();
+                        var tipoOrgaId = Orga.FirstOrDefault().TipoOrganizacionId;
+                        var TipoOrganizacion = db.TipoOrganizacion.Where(q => q.TipoOrganizacionId == tipoOrgaId).FirstOrDefault().Nombre;
+                        var docto = hsms.Sign(documento.File, idsFirma, documento.DocumentoId, documento.Folio, url_tramites_en_linea.Valor, qr, TipoOrganizacion);
                         documento.Content = docto;
                         //documento.Signed = true;
                         documento.Firmado = true;
@@ -6578,8 +6687,11 @@ namespace DAES.BLL
                                 response.Errors.Add(ex.Message);
                             }
                         }
-
-                        var docto = hsms.Sign(documento.Content, idsFirma, documento.DocumentoId, documento.Folio, url_tramites_en_linea.Valor, qr);
+                        var organizacionId = documento.OrganizacionId;
+                        var Orga = db.Organizacion.Where(q => q.OrganizacionId == organizacionId).ToList();
+                        var tipoOrgaId = Orga.FirstOrDefault().TipoOrganizacionId;
+                        var TipoOrganizacion = db.TipoOrganizacion.Where(q => q.TipoOrganizacionId == tipoOrgaId).FirstOrDefault().Nombre;
+                        var docto = hsms.Sign(documento.Content, idsFirma, documento.DocumentoId, documento.Folio, url_tramites_en_linea.Valor, qr, TipoOrganizacion);
                         documento.Content = docto;
                         //documento.Signed = true;
                         documento.Firmado = true;

--- a/DAES.Infrastructure/HSM/HSM.cs
+++ b/DAES.Infrastructure/HSM/HSM.cs
@@ -265,7 +265,7 @@ namespace DAES.Infrastructure.Hsm//verlo, posiblemente esta mal
             return documentoParaFirmar;
         }
 
-        public byte[] Sign(byte[] documento, List<string> firmantes, int documentoId, string folio, string url, byte[] QR)
+        public byte[] Sign(byte[] documento, List<string> firmantes, int documentoId, string folio, string url, byte[] QR, string TipoOrganizacion)
         {
             //validaciones
             if (documentoId == 0)
@@ -295,12 +295,16 @@ namespace DAES.Infrastructure.Hsm//verlo, posiblemente esta mal
                                 //obtener informacion de la primera pagina
                                 var pagesize = reader.GetPageSize(1);
                                 var pdfContentFirstPage = stamper.GetOverContent(1);
-
+                                
+                                //estampa tipo de organización
+                                ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(string.Format(TipoOrganizacion), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 185, 0);
+                                //ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(string.Format(TipoOrganizacion), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 152, 0);
                                 //estampa de folio
-                                ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(string.Format("Folio {0}", folio), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 167, 0);
-
+                                ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(string.Format("Folio {0}", folio), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 200, 0);
+                                //ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(string.Format("Folio wachinei{0}", folio), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 167, 0);
                                 //estampa de fecha
-                                ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(DateTime.Now.ToString("dd/MM/yyyy"), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 182, 0);
+                                ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(DateTime.Now.ToString("dd/MM/yyyy"), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 215, 0); 
+                                //ColumnText.ShowTextAligned(pdfContentFirstPage, Element.ALIGN_LEFT, new Phrase(DateTime.Now.ToString("dd/MM/yyyy"), new Font(Font.HELVETICA, 13, Font.BOLD, Color.DARK_GRAY)), pagesize.Width - 182, pagesize.Height - 182, 0);
                             }
                             catch (System.Exception ex)
                             {

--- a/DAES.Infrastructure/Interfaces/IHSM.cs
+++ b/DAES.Infrastructure/Interfaces/IHSM.cs
@@ -28,6 +28,6 @@ namespace DAES.Infrastructure.Interfaces
         /// <returns></returns>
         /// <exception cref="System.Exception"></exception>
         byte[] SignREST(byte[] documento, List<string> firmante, int documentoId, string folio, string urlVerificacion, byte[] qr);
-        byte[] Sign(byte[] documento, List<string> firmantes, int documentoId, string folio, string url, byte[] QR);
+        byte[] Sign(byte[] documento, List<string> firmantes, int documentoId, string folio, string url, byte[] QR, string TipoOrganizacion);
     }
 }

--- a/DAES.Model/SistemaIntegrado/ExistenciaPosterior.cs
+++ b/DAES.Model/SistemaIntegrado/ExistenciaPosterior.cs
@@ -51,8 +51,9 @@ namespace DAES.Model.SistemaIntegrado
         public int? OrganizacionId { get; set; }
         public virtual Organizacion Organizacion { get; set; }
 
+        [Column("LugarNotario")]
         [Display(Name = "Lugar notario")]
-        public string LugarNotario { get; set; }
+        public string LugarNotarioP { get; set; }
 
         [Display(Name = "Tipo Junta")]
         public int? TipoGeneralId { get; set; }

--- a/DAES.Model/SistemaIntegrado/Saneamiento.cs
+++ b/DAES.Model/SistemaIntegrado/Saneamiento.cs
@@ -42,8 +42,9 @@ namespace DAES.Model.SistemaIntegrado
         public int? OrganizacionId { get; set; }
         public virtual Organizacion Organizacion { get; set; }
 
+        [Column("LugarNotario")]
         [Display(Name = "Lugar notario")]
-        public string LugarNotario { get; set; }
+        public string LugarNotarioSa { get; set; }
 
 
 

--- a/DAES.Web.BackOffice/Views/Organizacion/Edit.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/Edit.cshtml
@@ -422,8 +422,7 @@
                 <input type="button" value="Limpiar campos" id="limpiarSan" class="btn btn-primary" />
                 @if (Model.Saneamientos.Any())
                 {
-
-                    @Html.ActionLink("Eliminar saneamiento", "EliminarSanemiento", "Organizacion", new { IdSaneamiento = Model.Saneamientos.FirstOrDefault().IdSaneamiento, IdOrganizacion = Model.OrganizacionId }, htmlAttributes: new { @class = "btn btn-success" })
+                    @Html.ActionLink("Eliminar saneamiento", "EliminarSanemiento", "Organizacion", new { IdSaneamiento = Model.Saneamientos.FirstOrDefault().IdSaneamiento, IdOrganizacion = Model.OrganizacionId }, htmlAttributes: new { @class = "btn btn-danger" })
                 }
             </div>
         }
@@ -497,7 +496,7 @@
         }
     }
 
-    <div class="panel panel-default" id="disolucionModulo">
+    <div class="panel panel-default">
         <div class="panel-heading">Disolución</div>
         <div class="panel-body">
             <div id="disolucion">

--- a/DAES.Web.BackOffice/Views/Organizacion/_AsociacionesEdit.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/_AsociacionesEdit.cshtml
@@ -6,44 +6,46 @@
         @Html.HiddenFor(m => m.OrganizacionId)
         @Html.HiddenFor(model => model.Disolucions[i].OrganizacionId)
         @Html.HiddenFor(model => model.Disolucions[i].DisolucionId)
-        <thead>
-            <tr>
-                <th>
-                    @Html.LabelFor(m => m.Disolucions[i].NumeroOficio, htmlAttributes: new { @class = "control-label col-md-10" })
-                    @Html.EditorFor(m => Model.Disolucions[i].NumeroOficio, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-                <th>
-                    @Html.LabelFor(m => m.Disolucions[i].FechaOficio, htmlAttributes: new { @class = "control-label col-md-10" })
-                    @Html.EditorFor(m => Model.Disolucions[i].FechaOficio, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-                <th>
-                    @Html.LabelFor(m => m.Disolucions[i].FechaAsambleaSocios, htmlAttributes: new { @class = "control-label col-md-10" })
-                    @Html.EditorFor(m => Model.Disolucions[i].FechaAsambleaSocios, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-            </tr>
-            <tr>
-                <th>
-                    @Html.LabelFor(m => m.Disolucions[i].FechaEscrituraPublica, htmlAttributes: new { @class = "control-label col-md-10" })
-                    @Html.EditorFor(m => Model.Disolucions[i].FechaEscrituraPublica, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-                <th>
-                    @Html.LabelFor(m => m.Disolucions[i].FechaPubliccionDiarioOficial, htmlAttributes: new { @class = "control-label col-md-10" })
-                    @Html.EditorFor(m => Model.Disolucions[i].FechaPubliccionDiarioOficial, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-                <th>
-                    @Html.LabelFor(m => m.Disolucions[i].NombreNotaria, htmlAttributes: new { @class = "control-label col-md-10" })
-                    @Html.EditorFor(m => Model.Disolucions[i].NombreNotaria, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-            </tr>
-            <tr>
-                <th>
-                    @Html.LabelFor(m => m.Disolucions[i].DatosNotario, htmlAttributes: new { @class = "control-label col-md-10" })
-                    @Html.EditorFor(m => Model.Disolucions[i].DatosNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-                <th>
-                    @Ajax.ActionLink("Eliminar", "DisolucionDelete", null, new { Model.Disolucions.ToArray()[i].DisolucionId, Model.Disolucions.ToArray()[i].OrganizacionId }, new AjaxOptions { UpdateTargetId = "disolucion" }, htmlAttributes: new { @class = "btn btn-danger" })
-                </th>
-            </tr>
-        </thead>
+    <thead>
+        <tr>
+            <th>
+                @Html.LabelFor(m => m.Disolucions[i].FechaAsambleaSocios, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].FechaAsambleaSocios, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+            <th>
+                @Html.LabelFor(m => m.Disolucions[i].FechaEscrituraPublica, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].FechaEscrituraPublica, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+            <th>
+                @Html.LabelFor(m => m.Disolucions[i].NombreNotaria, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].NombreNotaria, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+        </tr>
+        <tr>
+            <th>
+                @Html.LabelFor(m => m.Disolucions[i].DatosNotario, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].DatosNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+            <th>
+                @Html.LabelFor(m => m.Disolucions[i].FechaPubliccionDiarioOficial, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].FechaPubliccionDiarioOficial, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+            <th>
+                @Html.LabelFor(m => m.Disolucions[i].NumeroOficio, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].NumeroOficio, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+        </tr>
+        <tr>
+            <th>
+                @Html.LabelFor(m => m.Disolucions[i].FechaOficio, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].FechaOficio, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+        </tr>
+        <tr>
+            <th>
+                @Ajax.ActionLink("Eliminar", "DisolucionDelete", null, new { Model.Disolucions.ToArray()[i].DisolucionId, Model.Disolucions.ToArray()[i].OrganizacionId }, new AjaxOptions { UpdateTargetId = "disolucion" }, htmlAttributes: new { @class = "btn btn-danger" })
+            </th>
+        </tr>
+    </thead>
     }
 </table>

--- a/DAES.Web.BackOffice/Views/Organizacion/_CoopAnterior.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/_CoopAnterior.cshtml
@@ -23,6 +23,10 @@
         </tr>
         <tr>
             <th>
+                @Html.LabelFor(m => Model.Disolucions[i].Autorizacion, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].Autorizacion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            </th>
+            <th>
                 @Html.LabelFor(m => Model.Disolucions[i].FechaPubliccionDiarioOficial, htmlAttributes: new { @class = "control-label col-md-10" })
                 @if (Model.Disolucions.FirstOrDefault().FechaPubliccionDiarioOficial != null)
                 {
@@ -32,10 +36,6 @@
                 {
                     @Html.EditorFor(m => Model.Disolucions[i].FechaPubliAnterior, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 }
-            </th>
-            <th>
-                @Html.LabelFor(m => Model.Disolucions[i].Autorizacion, htmlAttributes: new { @class = "control-label col-md-10" })
-                @Html.EditorFor(m => Model.Disolucions[i].Autorizacion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
             <th>
                 @Html.LabelFor(m => Model.Disolucions[i].FechaJuntaSocios, htmlAttributes: new { @class = "control-label col-md-10" })
@@ -49,21 +49,34 @@
                 }
             </th>
         </tr>
+        <!--tr>
+            <th>
+                Html.LabelFor(m => Model.Disolucions[i].DatosNotario, htmlAttributes: new { class = "control-label col-md-10" })
+                Html.EditorFor(m => Model.Disolucions[i].DatosNotario, new { htmlAttributes = new { class = "form-control col-md-10" } })
+            </th>
+            <th>
+                Html.LabelFor(m => Model.Disolucions[i].NombreNotaria, htmlAttributes: new { class = "control-label col-md-10" })
+                Html.EditorFor(m => Model.Disolucions[i].NombreNotaria, new { htmlAttributes = new { class = "form-control col-md-10" } })
+            </th>
+            <th>
+            </th>
+        </tr-->
         <tr>
+            <th> 
+                    @Html.LabelFor(m => Model.Disolucions[i].ComisionAnterior, htmlAttributes: new { @class = "control-label col-md-7" })
+                    @Html.EditorFor(m => Model.Disolucions[i].ComisionAnterior, new { htmlAttributes = new { @id = "comisionAnterior", @class = "control-label", @style = "height: 20px;" } } )
+</th>
             <th>
-                @Html.LabelFor(m => Model.Disolucions[i].DatosNotario, htmlAttributes: new { @class = "control-label col-md-10" })
-                @Html.EditorFor(m => Model.Disolucions[i].DatosNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
             <th>
-                @Html.LabelFor(m => Model.Disolucions[i].NombreNotaria, htmlAttributes: new { @class = "control-label col-md-10" })
-                @Html.EditorFor(m => Model.Disolucions[i].NombreNotaria, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
-            <th>
+
+        </tr>
+        <tr>
+            <th >
                 @Html.LabelFor(m => Model.Disolucions[i].FechaComiLiquiJuntaSocios, htmlAttributes: new { @class = "control-label col-md-10" })
                 @Html.EditorFor(m => Model.Disolucions[i].FechaComiLiquiJuntaSocios, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
-        </tr>
-        <tr>
             <th>
                 @Html.LabelFor(m => Model.Disolucions[i].FechaInicio, htmlAttributes: new { @class = "control-label col-md-10" })
                 @Html.EditorFor(m => Model.Disolucions[i].FechaInicio, new { htmlAttributes = new { @class = "form-control col-md-10" } })
@@ -72,10 +85,7 @@
                 @Html.LabelFor(m => Model.Disolucions[i].FechaTermino, htmlAttributes: new { @class = "control-label col-md-10" })
                 @Html.EditorFor(m => Model.Disolucions[i].FechaTermino, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
-            <th>
-                @Html.LabelFor(m => Model.Disolucions[i].ComisionAnterior, htmlAttributes: new { @class = "control-label col-md-10" })
-                @Html.EditorFor(m => Model.Disolucions[i].ComisionAnterior, new { htmlAttributes = new { @id = "comisionAnterior", @class = "form-control", @style = "height: 20px;" } })
-            </th>
+
 
         </tr>
         <tr>

--- a/DAES.Web.BackOffice/Views/Organizacion/_CoopPosterior.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/_CoopPosterior.cshtml
@@ -45,14 +45,14 @@
                 @Html.EditorFor(m => Model.Disolucions[i].NumeroFojas, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
             <th>
-                @Html.LabelFor(m => Model.Disolucions[i].AñoInscripcion, htmlAttributes: new { @class = "control-label col-md-10" })
-                @Html.EditorFor(m => Model.Disolucions[i].AñoInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                @Html.LabelFor(m => Model.Disolucions[i].DatosCBR, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].DatosCBR, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
         </tr>
         <tr>
             <th>
-                @Html.LabelFor(m => Model.Disolucions[i].DatosCBR, htmlAttributes: new { @class = "control-label col-md-10" })
-                @Html.EditorFor(m => Model.Disolucions[i].DatosCBR, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                @Html.LabelFor(m => Model.Disolucions[i].AñoInscripcion, htmlAttributes: new { @class = "control-label col-md-10" })
+                @Html.EditorFor(m => Model.Disolucions[i].AñoInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
             <th>
                 @Html.LabelFor(m => Model.Disolucions[i].DatosNotario, htmlAttributes: new { @class = "control-label col-md-10" })
@@ -63,7 +63,16 @@
                 @Html.EditorFor(m => Model.Disolucions[i].NombreNotaria, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
         </tr>
-
+        <tr>
+            <th>
+                @Html.LabelFor(m => Model.Disolucions[i].ComisionPosterior, htmlAttributes: new { @class = "control-label col-md-7" })
+                @Html.EditorFor(m => Model.Disolucions[i].ComisionPosterior, new { htmlAttributes = new { @id = "comisionPosterior", @class = "form-label", @style = "height: 20px;" } })
+            </th>
+            <th>
+            </th>
+            <th>
+            </th>
+        </tr>
         <tr>
             <th>
                 @Html.LabelFor(m => Model.Disolucions[i].FechaComiLiquiJuntaSocios, htmlAttributes: new { @class = "control-label col-md-10" })
@@ -78,16 +87,7 @@
                 @Html.EditorFor(m => Model.Disolucions[i].FechaTermino, new { htmlAttributes = new { @class = "form-control col-md-10" } })
             </th>
         </tr>
-        <tr>
-            <th>
-                @Html.LabelFor(m => Model.Disolucions[i].ComisionPosterior, htmlAttributes: new { @class = "control-label col-md-10" })
-                @Html.EditorFor(m => Model.Disolucions[i].ComisionPosterior, new { htmlAttributes = new { @id = "comisionPosterior", @class = "form-control", @style = "height: 20px;" } })
-            </th>
-            <th>
-            </th>
-            <th>
-            </th>
-        </tr>
+
         <tr>
             <th>
             </th>

--- a/DAES.Web.BackOffice/Views/Organizacion/_ExistenciaAnterior.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/_ExistenciaAnterior.cshtml
@@ -22,22 +22,23 @@
             </tr>
             <tr>
                 <th>
-                    @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaPublicacion)
-                    @Html.EditorFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaPublicacion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-                </th>
-                <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().Autorizado)
                     @Html.EditorFor(model => Model.ExistenciaAnteriors.FirstOrDefault().Autorizado, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaJuntaGeneral)
-                    @Html.EditorFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaJuntaGeneral, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                    @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaPublicacion)
+                    @Html.EditorFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaPublicacion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().TipoGeneralId)
+                    @Html.DropDownListFor(model => model.ExistenciaAnteriors.FirstOrDefault().TipoGeneralId, null, "Seleccione...", new { @class = "form-control col-md-10" })
+
                 </th>
             </tr>
             <tr>
                 <th>
-                    @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().TipoGeneralId)
-                    @Html.DropDownListFor(model => model.ExistenciaAnteriors.FirstOrDefault().TipoGeneralId, null, "Seleccione...", new { @class = "form-control col-md-10" })
+                    @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaJuntaGeneral)
+                    @Html.EditorFor(model => Model.ExistenciaAnteriors.FirstOrDefault().FechaJuntaGeneral, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaAnteriors.FirstOrDefault().LugarNotario)
@@ -85,22 +86,22 @@
     </tr>
     <tr>
         <th>
-            @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].FechaPublicacion)
-            @Html.EditorFor(model => Model.ExistenciaAnteriors[i].FechaPublicacion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
-        </th>
-        <th>
             @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].Autorizado)
             @Html.EditorFor(model => Model.ExistenciaAnteriors[i].Autorizado, new { htmlAttributes = new { @class = "form-control col-md-10" } })
         </th>
         <th>
-            @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].FechaJuntaGeneral)
-            @Html.EditorFor(model => Model.ExistenciaAnteriors[i].FechaJuntaGeneral, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+            @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].FechaPublicacion)
+            @Html.EditorFor(model => Model.ExistenciaAnteriors[i].FechaPublicacion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+        </th>
+        <th>
+            @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].TipoGeneralId)
+            @Html.DropDownListFor(model => Model.ExistenciaAnteriors[i].TipoGeneralId, new SelectList(ViewBag.TipoGeneralId, "Value", "Text", Model.ExistenciaAnteriors[i].TipoGeneralId), "Seleccione...", new { @class = "form-control col-md-10" })
         </th>
     </tr>
     <tr>
         <th>
-            @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].TipoGeneralId)
-            @Html.DropDownListFor(model => Model.ExistenciaAnteriors[i].TipoGeneralId, new SelectList(ViewBag.TipoGeneralId, "Value", "Text", Model.ExistenciaAnteriors[i].TipoGeneralId), "Seleccione...", new { @class = "form-control col-md-10" })
+            @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].FechaJuntaGeneral)
+            @Html.EditorFor(model => Model.ExistenciaAnteriors[i].FechaJuntaGeneral, new { htmlAttributes = new { @class = "form-control col-md-10" } })
         </th>
         <th>
             @Html.DisplayNameFor(model => Model.ExistenciaAnteriors[i].LugarNotario)

--- a/DAES.Web.BackOffice/Views/Organizacion/_ModificacionAG.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/_ModificacionAG.cshtml
@@ -10,23 +10,23 @@
             <tr>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals.FirstOrDefault().FechaConstitutivaSocios)
-                    @Html.EditorFor(model => Model.ExistenciaLegals.FirstOrDefault().FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control", @style = "width: 190px;" } })
+                    @Html.EditorFor(model => Model.ExistenciaLegals.FirstOrDefault().FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control col-md-10" } })
 
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals.FirstOrDefault().NumeroOficio)
-                    @Html.EditorFor(model => Model.ExistenciaLegals.FirstOrDefault().NumeroOficio, new { htmlAttributes = new { min = 0, @class = "form-control", @style = "width: 190px;" } })
+                    @Html.EditorFor(model => Model.ExistenciaLegals.FirstOrDefault().NumeroOficio, new { htmlAttributes = new { min = 0, @class = "form-control col-md-10" } })
                 </th>
 
             </tr>
             <tr>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals.FirstOrDefault().FechaOficio)
-                    @Html.EditorFor(model => Model.ExistenciaLegals.FirstOrDefault().FechaOficio, new { htmlAttributes = new { @class = "form-control", @style = "width: 190px;" } })
+                    @Html.EditorFor(model => Model.ExistenciaLegals.FirstOrDefault().FechaOficio, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals.FirstOrDefault().AprobacionId)
-                    @Html.DropDownListFor(model => model.ExistenciaLegals.FirstOrDefault().AprobacionId, null, "Selecione..", htmlAttributes: new { @class = "form-control", @style = "width: 190px;" })
+                    @Html.DropDownListFor(model => model.ExistenciaLegals.FirstOrDefault().AprobacionId, null, "Selecione..", htmlAttributes: new { @class = "form-control col-md-10" } )
                 </th>
             </tr>
             <tr>
@@ -44,23 +44,23 @@
             <tr>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals[i].FechaConstitutivaSocios)
-                    @Html.EditorFor(model => Model.ExistenciaLegals[i].FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control", @style = "width: 190px;" } })
+                    @Html.EditorFor(model => Model.ExistenciaLegals[i].FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control col-md-10" } })
 
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals[i].NumeroOficio)
-                    @Html.EditorFor(model => Model.ExistenciaLegals[i].NumeroOficio, new { htmlAttributes = new { min = 0, @class = "form-control", @style = "width: 190px;" } })
+                    @Html.EditorFor(model => Model.ExistenciaLegals[i].NumeroOficio, new { htmlAttributes = new { min = 0, @class = "form-control col-md-10" } })
                 </th>
 
             </tr>
             <tr>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals[i].FechaOficio)
-                    @Html.EditorFor(model => Model.ExistenciaLegals[i].FechaOficio, new { htmlAttributes = new { @class = "form-control", @style = "width: 190px;" } })
+                    @Html.EditorFor(model => Model.ExistenciaLegals[i].FechaOficio, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => Model.ExistenciaLegals[i].AprobacionId)
-                    @Html.DropDownListFor(model => Model.ExistenciaLegals[i].AprobacionId, new SelectList(ViewBag.AprobacionId, "Value", "Text", Model.ExistenciaLegals[i].AprobacionId), "Seleccione...", new { @class = "form-control", @style = "width: 190px;", onchange = "PresentarViewObservacionLegal(this.value);" })
+                    @Html.DropDownListFor(model => Model.ExistenciaLegals[i].AprobacionId, new SelectList(ViewBag.AprobacionId, "Value", "Text", Model.ExistenciaLegals[i].AprobacionId), "Seleccione...", new { @class = "form-control col-md-10", onchange = "PresentarViewObservacionLegal(this.value);" })
                 </th>
 
             </tr>

--- a/DAES.Web.BackOffice/Views/Organizacion/_ModificacionCPostRPostEdit.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/_ModificacionCPostRPostEdit.cshtml
@@ -14,22 +14,22 @@
                     <thead>
                         <tr>
                             <th>
-                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].FechaConstitutivaSocios)
-                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].TipoGeneralId)
+                                @Html.DropDownListFor(model => Model.ExistenciaPosteriors[i].TipoGeneralId, new SelectList(ViewBag.TipoGeneralId, "Value", "Text", Model.ExistenciaPosteriors[i].TipoGeneralId), "Seleccione...", new { @class = "form-control col-md-10" })
                             </th>
                             <th>
-                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].FechaEscrituraPublica)
-                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].FechaEscrituraPublica, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].FechaConstitutivaSocios)
+                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                             </th>
                         </tr>
                         <tr>
                             <th>
-                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].FechaPublicacionn)
-                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].FechaPublicacionn, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].FechaEscrituraPublica)
+                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].FechaEscrituraPublica, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                             </th>
                             <th>
-                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].TipoGeneralId)
-                                @Html.DropDownListFor(model => Model.ExistenciaPosteriors[i].TipoGeneralId, new SelectList(ViewBag.TipoGeneralId, "Value", "Text", Model.ExistenciaPosteriors[i].TipoGeneralId), "Seleccione...", new { @class = "form-control col-md-10" })
+                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].LugarNotarioP)
+                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].LugarNotarioP, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                             </th>
                         </tr>
                         <tr>
@@ -38,24 +38,25 @@
                                 @Html.EditorFor(model => model.ExistenciaPosteriors[i].DatosGeneralesNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                             </th>
                             <th>
-                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].LugarNotario)
-                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].LugarNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].FechaPublicacionn)
+                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].FechaPublicacionn, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                            <th>
                         </tr>
                         <tr>
                             <th>
                                 @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].Fojas)
-                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].Fojas, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].Fojas, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                             </th>
                             <th>
-                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].AnoInscripcion)
-                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].AnoInscripcion, new { htmlAttributes = new { @class = "form-control" } })
+                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].DatosCBR)
+                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].DatosCBR, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+
                             </th>
                         </tr>
                         <tr>
-                            <th colspan="2">
-                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].DatosCBR)
-                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].DatosCBR, new { htmlAttributes = new { @class = "form-control", @style = "max-width: 1200px;" } })
-
+                            <th>
+                                @Html.DisplayNameFor(model => Model.ExistenciaPosteriors[i].AnoInscripcion)
+                                @Html.EditorFor(model => model.ExistenciaPosteriors[i].AnoInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                             </th>
                         </tr>
                     </thead>
@@ -76,24 +77,23 @@
                     <tr>
 
                         <th>
-                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().FechaConstitutivaSocios)
-                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control" } })
-
+                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().TipoGeneralId)
+                            @Html.DropDownListFor(model => model.ExistenciaPosteriors.FirstOrDefault().TipoGeneralId, null, "Seleccione...", new { @class = "form-control col-md-10" })
                         </th>
                         <th>
-                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().FechaEscrituraPublica)
-                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().FechaEscrituraPublica, new { htmlAttributes = new { @class = "form-control" } })
+                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().FechaConstitutivaSocios)
+                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().FechaConstitutivaSocios, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                         </th>
                     </tr>
                     <tr>
                         <th>
-                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().FechaPublicacionn)
-                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().FechaPublicacionn, new { htmlAttributes = new { @class = "form-control" } })
+                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().FechaEscrituraPublica)
+                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().FechaEscrituraPublica, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                         </th>
                         <th>
-                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().TipoGeneralId)
-                            @Html.DropDownListFor(model => model.ExistenciaPosteriors.FirstOrDefault().TipoGeneralId, null, "Seleccione...", new { @class = "form-control col-md-10" })
-                        <th>
+                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().LugarNotarioP)
+                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().LugarNotarioP, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+</th>
                     </tr>
                     <tr>
                         <th>
@@ -101,26 +101,25 @@
                             @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().DatosGeneralesNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                         </th>
                         <th>
-                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().LugarNotario)
-                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().LugarNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().FechaPublicacionn)
+                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().FechaPublicacionn, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                         </th>
-                    </tr>
+</tr>
                     <tr>
                         <th>
                             @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().Fojas)
-                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().Fojas, new { htmlAttributes = new { @class = "form-control" } })
+                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().Fojas, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                         </th>
 
                         <th>
-                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().AnoInscripcion)
-                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().AnoInscripcion, new { htmlAttributes = new { @class = "form-control" } })
+                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().DatosCBR)
+                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().DatosCBR, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                         </th>
                     </tr>
                     <tr>
-                        <th colspan="2">
-                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().DatosCBR)
-                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().DatosCBR, new { htmlAttributes = new { @class = "form-control", @style = "max-width: 1200px;" } })
-
+                        <th>
+                            @Html.DisplayNameFor(model => Model.ExistenciaPosteriors.FirstOrDefault().AnoInscripcion)
+                            @Html.EditorFor(model => model.ExistenciaPosteriors.FirstOrDefault().AnoInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                         </th>
                     </tr>
                 </thead>

--- a/DAES.Web.BackOffice/Views/Organizacion/_SaneamientoEdit.cshtml
+++ b/DAES.Web.BackOffice/Views/Organizacion/_SaneamientoEdit.cshtml
@@ -11,8 +11,8 @@
                     @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().FechaEscrituraPublicaa, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().FechaaPublicacionDiario)
-                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().FechaaPublicacionDiario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().LugarNotarioSa)
+                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().LugarNotarioSa, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
             </tr>
             <tr>
@@ -20,9 +20,9 @@
                     @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().DatoGeneralesNotario)
                     @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().DatoGeneralesNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
-                <th >
-                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().LugarNotario)
-                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().LugarNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                <th>
+                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().FechaaPublicacionDiario)
+                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().FechaaPublicacionDiario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
             </tr>
             <tr>
@@ -31,14 +31,15 @@
                     @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().Fojass, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().FechaaInscripcion)
-                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().FechaaInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().DatossCBR)
+                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().DatossCBR, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+
                 </th>
             </tr>
             <tr>
-                <th colspan="2">
-                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().DatossCBR)
-                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().DatossCBR, new { htmlAttributes = new { @class = "form-control ", @style= "max-width: 1200px;" } })
+                <th>
+                    @Html.DisplayNameFor(model => Model.Saneamientos.FirstOrDefault().FechaaInscripcion)
+                    @Html.EditorFor(model => Model.Saneamientos.FirstOrDefault().FechaaInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
             </tr>
         </thead>
@@ -55,8 +56,8 @@
                     @Html.EditorFor(model => Model.Saneamientos[i].FechaEscrituraPublicaa, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => Model.Saneamientos[i].FechaaPublicacionDiario)
-                    @Html.EditorFor(model => Model.Saneamientos[i].FechaaPublicacionDiario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                    @Html.DisplayNameFor(model => Model.Saneamientos[i].LugarNotarioSa)
+                    @Html.EditorFor(model => Model.Saneamientos[i].LugarNotarioSa, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
             </tr>
             <tr>
@@ -65,8 +66,8 @@
                     @Html.EditorFor(model => Model.Saneamientos[i].DatoGeneralesNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => Model.Saneamientos[i].LugarNotario)
-                    @Html.EditorFor(model => Model.Saneamientos[i].LugarNotario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                    @Html.DisplayNameFor(model => Model.Saneamientos[i].FechaaPublicacionDiario)
+                    @Html.EditorFor(model => Model.Saneamientos[i].FechaaPublicacionDiario, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
             </tr>
             <tr>
@@ -75,14 +76,15 @@
                     @Html.EditorFor(model => Model.Saneamientos[i].Fojass, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => Model.Saneamientos[i].FechaaInscripcion)
-                    @Html.EditorFor(model => Model.Saneamientos[i].FechaaInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+                    @Html.DisplayNameFor(model => Model.Saneamientos[i].DatossCBR)
+                    @Html.EditorFor(model => Model.Saneamientos[i].DatossCBR, new { htmlAttributes = new { @class = "form-control col-md-10" } })
+
                 </th>
             </tr>
             <tr>
-                <th colspan="2">
-                    @Html.DisplayNameFor(model => Model.Saneamientos[i].DatossCBR)
-                    @Html.EditorFor(model => Model.Saneamientos[i].DatossCBR, new { htmlAttributes = new { @class = "form-control", @style = "max-width: 1200px;" } })
+                <th>
+                    @Html.DisplayNameFor(model => Model.Saneamientos[i].FechaaInscripcion)
+                    @Html.EditorFor(model => Model.Saneamientos[i].FechaaInscripcion, new { htmlAttributes = new { @class = "form-control col-md-10" } })
                 </th>
             </tr>
         </thead>


### PR DESCRIPTION
cambios:
se ordenaron modulos en el edit organizacion(BO)
   -saneamiento
   -existencias
   -disolución

se reordeno la parte superior del documento(todos) ahora imagen, titulo y folio lo muestra en "cascada"

el saludo junto con el responsable(final del PDF) ya no se coloca sobre la firma y no se "corta" entre pag   

algunos de los campos que lo guardaba en "create" se solucionaron